### PR TITLE
Address kroo/reflex-clerk#6: pydantic import error

### DIFF
--- a/clerk_demo/requirements.txt
+++ b/clerk_demo/requirements.txt
@@ -1,2 +1,2 @@
-reflex==0.5.1
+reflex==0.5.5
 reflex-clerk

--- a/custom_components/reflex_clerk/clerk_client/clerk_request_models.py
+++ b/custom_components/reflex_clerk/clerk_client/clerk_request_models.py
@@ -1,6 +1,9 @@
 from typing import Optional, List
 
-from reflex.base import pydantic
+try:
+    from reflex.base import pydantic
+except ImportError:
+    import pydantic
 
 
 class VerifyClientRequest(pydantic.BaseModel):

--- a/custom_components/reflex_clerk/clerk_client/clerk_response_models.py
+++ b/custom_components/reflex_clerk/clerk_client/clerk_response_models.py
@@ -1,6 +1,9 @@
 from typing import Optional, List, Dict, Any, Literal
 
-from reflex.base import pydantic
+try:
+    from reflex.base import pydantic
+except ImportError:
+    import pydantic
 
 
 class ClerkError(pydantic.BaseModel):

--- a/custom_components/reflex_clerk/lib/appearance.py
+++ b/custom_components/reflex_clerk/lib/appearance.py
@@ -1,6 +1,9 @@
 import typing
 
-from reflex.base import pydantic
+try:
+    from reflex.base import pydantic
+except ImportError:
+    import pydantic
 
 
 class AppearanceVariables(pydantic.BaseModel):


### PR DESCRIPTION
0.5.4 resolves the need to import pydantic from
reflex.base, allowing us to import pydantic directly.